### PR TITLE
Fixs : filteredOperations input is ignored due to typo in action arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
     microcks-cli test '${{ inputs.apiNameAndVersion }}' ${{ inputs.testEndpoint }} ${{ inputs.runner }} \
       --microcksURL=${{ inputs.microcksURL }} --waitFor=${{ inputs.waitFor }} --secretName='${{ inputs.secretName }}' \
       --keycloakClientId=${{ inputs.keycloakClientId }} --keycloakClientSecret=${{ inputs.keycloakClientSecret }} \
-      --insecure --filteredOperations='${{ inputs.filterOperations }}' --operationsHeaders='${{ inputs.operationsHeaders }}'
+      --insecure --filteredOperations='${{ inputs.filteredOperations }}' --operationsHeaders='${{ inputs.operationsHeaders }}'
 branding:
   icon: 'upload-cloud'  
   color: 'blue'


### PR DESCRIPTION
### Description
------
Corrected a typo in the action.yml file where the filteredOperations input was referenced as filterOperations.
Ensured that the value provided to the filteredOperations input is correctly passed to the microcks-cli via the --filteredOperations flag.
Verified that the flag name has been --filteredOperations (with 'd') since its introduction in CLI version 0.5.3, ensuring compatibility with the pinned version 0.5.6.

### Related issue(s)
----------------
Fixes #87 